### PR TITLE
feat: add support for `randrand` in `FIO` jobs

### DIFF
--- a/ceph_perftest/single_device/run.py
+++ b/ceph_perftest/single_device/run.py
@@ -95,8 +95,9 @@ def run_fio(fio_exe, device, max_numjobs, cleanup, outdir, bs, mode, runtime, fi
         )
         
         data = json.load(f)
-
-
+        _mode = mode
+        if _mode == 'randread':
+            _mode = 'read'
         jobs = [i[mode] for i in data['jobs']]
 
         if cleanup:

--- a/ceph_perftest/single_host/run.py
+++ b/ceph_perftest/single_host/run.py
@@ -130,7 +130,10 @@ def run_fio(fio_exe, input_devices, cleanup, outdir, bs, mode, runtime, filesize
                 device=device
                 )
             )
-            dev_data = [i[mode] for i in data['jobs'] if i['jobname'] == device_name][0]
+            _mode = mode
+            if _mode == 'randread':
+                _mode = 'read'
+            dev_data = [i[_mode] for i in data['jobs'] if i['jobname'] == device_name][0]
             count_output.update(
                     {
                         device: {


### PR DESCRIPTION
The output produced by `fio` will use `read` key for both `read` and `randread` jobs. If you use `rw=randread` you will hit a `Key Error` as the data extraction assumed `mode` was a `1:1` match.