### PR TITLE
feat: add support for `randwrite` in FIO jobs

### DIFF
--- a/ceph_perftest/single_device/run.py
+++ b/ceph_perftest/single_device/run.py
@@ -98,6 +98,8 @@ def run_fio(fio_exe, device, max_numjobs, cleanup, outdir, bs, mode, runtime, fi
         _mode = mode
         if _mode == 'randread':
             _mode = 'read'
+        elif _mode == 'randwrite':
+            _mode = 'write'
         jobs = [i[mode] for i in data['jobs']]
 
         if cleanup:

--- a/ceph_perftest/single_host/run.py
+++ b/ceph_perftest/single_host/run.py
@@ -133,6 +133,8 @@ def run_fio(fio_exe, input_devices, cleanup, outdir, bs, mode, runtime, filesize
             _mode = mode
             if _mode == 'randread':
                 _mode = 'read'
+            elif _mode == 'randwrite':
+                _mode = 'write'
             dev_data = [i[_mode] for i in data['jobs'] if i['jobname'] == device_name][0]
             count_output.update(
                     {


### PR DESCRIPTION
The output produced by `fio` will use `write` key for both `write` and `randwrite` jobs. If you use `rw=randwrite` you will hit a `Key Error` as the data extraction assumed `mode` was a `1:1` match.